### PR TITLE
main: set default config to __not_load_modules

### DIFF
--- a/userbot/__main__.py
+++ b/userbot/__main__.py
@@ -18,7 +18,7 @@ class _Modules:
     def __init__(self):
         self.__imported_module = None
         self.__load_modules_count = 0
-        self.__not_load_modules = getConfig("NOT_LOAD_MODULES")
+        self.__not_load_modules = getConfig("NOT_LOAD_MODULES", [])
 
     def __load_modules(self) -> tuple:
         all_modules = []


### PR DESCRIPTION
Without default config bot will run into critical crash if user modules are present without NOT_LOAD_MODULES config set in config file